### PR TITLE
Add automatic setup to install adar on ubuntu 18.04 and ubuntu 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,36 @@ Das System wird von mir aktiv zur Datenablage genutzt. Hierzu werden PDF-Dateien
    - z.B. ```*/15 * * * * /usr/bin/php -f /var/www/cron.php > /var/log/adar.cron.log``` in crontab
  - Login mit admin/admin
 
+### Ubuntu Bionic (nur i686 / 32 Bit)
+
+Für Ubuntu Bionic steht ein automatisches Installationsscript mit Konfigurationsassistent in [doc/setup-ubuntu18.04.sh](https://github.com/adlerweb/adar/blob/master/doc/setup-ubuntu18.04.sh) zur Verfügung:
+
+````
+sudo -s
+pushd /tmp
+wget "https://raw.githubusercontent.com/adlerweb/adar/master/doc/setup-ubuntu18.04.sh"
+chmod +x setup-ubuntu18.04.sh
+./setup-ubuntu18.04.sh
+popd
+````
+
+Dies installiert alle Voraussetzungen (Apache/MariaDB, etc), ändert die Konfigurationen, erstellt die Datenbank und legt ein Login-Passwort fest. Da hierbei Systemkonfigurationen geändert werden sollte das Script nur auf ausschließlich für AdAr vorgesehenen Systemen (VM, Container, etc) verwendet werden.
+
+### Ubuntu Xenial (nur i686 / 32 Bit)
+
+Für Ubuntu Xenial steht ein automatisches Installationsscript mit Konfigurationsassistent in [doc/setup-ubuntu16.04.sh](https://github.com/adlerweb/adar/blob/master/doc/setup-ubuntu16.04.sh) zur Verfügung:
+
+````
+sudo -s
+pushd /tmp
+wget "https://raw.githubusercontent.com/adlerweb/adar/master/doc/setup-ubuntu16.04.sh"
+chmod +x setup-ubuntu16.04.sh
+./setup-ubuntu16.04.sh
+popd
+````
+
+Dies installiert alle Voraussetzungen (Apache/MariaDB, etc), ändert die Konfigurationen, erstellt die Datenbank und legt ein Login-Passwort fest. Da hierbei Systemkonfigurationen geändert werden sollte das Script nur auf ausschließlich für AdAr vorgesehenen Systemen (VM, Container, etc) verwendet werden.
+
 ### Debian Jessie
 
 Für Debian Jessie steht ein automatisches Installationsscript mit Konfigurationsassistent in [doc/setup-debian8.sh](https://github.com/adlerweb/adar/blob/master/doc/setup-debian8.sh) zur Verfügung:
@@ -52,7 +82,7 @@ Für Debian Jessie steht ein automatisches Installationsscript mit Konfiguration
 ````
 pushd /tmp
 wget "https://raw.githubusercontent.com/adlerweb/adar/master/doc/setup-debian8.sh"
-bash setup-debian8.de
+bash setup-debian8.sh
 popd
 ````
 

--- a/doc/setup-ubuntu16.04.sh
+++ b/doc/setup-ubuntu16.04.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+#Voraussetzungen aus Paketquellen Installieren
+apt-get update
+apt-get install mariadb-server mariadb-client apache2 imagemagick tesseract-ocr tesseract-ocr-deu poppler-utils git apt-transport-https wget
+# "root"-Passwort für MySQL/MariaDB setzen (und merken)
+
+#PHP7
+apt-get update
+apt-get install php7.0 php7.0-cli php7.0-mysql php7.0-gd libapache2-mod-php7.0 php7.0-opcache php7.0-zip
+
+#PHP konfigurieren
+phpenmod gd
+phpenmod mysqli
+phpenmod opcache
+phpenmod zip
+sed -e "s/memory_limit = 128M/memory_limit = 512M/g" /etc/php/7.0/apache2/php.ini > /etc/php/7.0/apache2/php.ini.tmp && mv /etc/php/7.0/apache2/php.ini.tmp /etc/php/7.0/apache2/php.ini
+sed -e "s/memory_limit = 128M/memory_limit = 512M/g" /etc/php/7.0/cli/php.ini > /etc/php/7.0/cli/php.ini.tmp && mv /etc/php/7.0/cli/php.ini.tmp /etc/php/7.0/cli/php.ini
+systemctl restart apache2.service
+
+#Composer ist bisher nur in Testing vorhanden, daher installieren wir nun manuell
+pushd /tmp
+wget -O - "https://gist.githubusercontent.com/adlerweb/b63784bd859e63ac0bbd8ea85ec161da/raw/54ae771120880364df75141f9d5c39bd82439a4c/composersetup.sh" | sh
+mv composer.phar /usr/local/bin/composer
+popd
+
+#AdAr Herunterladen
+install -o www-data -d /var/www/html/adar/
+pushd /var/www/html/adar
+su -s $SHELL -c 'git clone https://github.com/adlerweb/adar.git .' www-data
+
+#Abhängigkeiten installieren
+install -o www-data -d /var/www/.composer/
+su -s $SHELL -c 'composer install' www-data
+
+#MySQL/MariaDB einrichten
+read -s -p "Database root password? " sqlroot
+echo
+sqlpw=$(base64 /dev/urandom | tr -d '/+' | dd bs=32 count=1 2>/dev/null)
+
+sql="CREATE USER 'adar'@'localhost' IDENTIFIED BY '$sqlpw'; "
+sql+="CREATE DATABASE adar; "
+sql+="GRANT ALL PRIVILEGES ON \`adar\`.* TO 'adar'@'localhost'; "
+sql+="FLUSH PRIVILEGES; "
+sql+="USE adar; "
+sql+=$(cat doc/mysql.sql)
+echo "$sql" | mysql -uroot -p"$sqlroot"
+unset sqlroot
+unset sql
+
+#Konfiguration anpassen
+sed -e "s/testinstallation/$sqlpw/g" config.php > config.php.tmp && mv config.php.tmp config.php
+
+read -p "Absendeadresse für E-Mails? [ADAR <adar@localhost>] " cfgtmp
+echo
+if [[ -z "${cfgtmp// }" ]] ;then
+	cfgtmp="ADAR <adar@localhost>"
+fi
+sed -e "s/ADAR <adar@localhost>/$cfgtmp/g" config.php > config.php.tmp && mv config.php.tmp config.php
+
+read -p "E-Mail für Benachrichtigung bei Neuanlagen? (Leer = Keine Infomail) " cfgtmp
+echo
+if [[ ! -z "${cfgtmp// }" ]] ;then
+	sed -e "s/''/'$cfgtmp'/g" config.php > config.php.tmp && mv config.php.tmp config.php
+fi
+
+unset cfgtmp
+
+# Admin-Passwort festlegen
+read -s -p "Passwort für admin? " cfgtmp
+echo
+
+cfgtmp=$(echo "<?php require('vendor/adlerweb/awtools/session.php'); \$sess = new adlerweb_session; echo \$sess->session_getNewPasswordHash("$cfgtmp"); ?>" | php 2>/dev/null)
+
+if [[ ! -z "${cfgtmp// }" ]] ;then
+	echo "UPDATE Users SET Password = '$cfgtmp' WHERE Nickname = 'admin' LIMIT 1;" | mysql -uadar -p"$sqlpw" adar
+else
+	echo "Fehler - Passwort wurde nicht geändert, login mit admin:admin"
+fi
+
+unset sqlpw
+unset cfgtmp
+
+#Cronjob einrichten
+echo '*/5 * * * * /usr/bin/php -f /var/www/html/adar/cron.php > /var/log/adar.cron.log' > /etc/cron.d/adar
+
+#Done
+popd
+echo Setup abgeschlossen

--- a/doc/setup-ubuntu18.04.sh
+++ b/doc/setup-ubuntu18.04.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+#Voraussetzungen aus Paketquellen Installieren
+apt-get update
+apt-get install mariadb-server mariadb-client apache2 imagemagick tesseract-ocr tesseract-ocr-deu poppler-utils git apt-transport-https wget
+# "root"-Passwort für MySQL/MariaDB setzen (und merken)
+
+#PHP7
+apt-get update
+apt-get install php7.2 php7.2-cli php7.2-mysql php7.2-gd libapache2-mod-php7.2 php7.2-opcache php7.2-zip
+
+#PHP konfigurieren
+phpenmod gd
+phpenmod mysqli
+phpenmod opcache
+phpenmod zip
+sed -e "s/memory_limit = 128M/memory_limit = 512M/g" /etc/php/7.2/apache2/php.ini > /etc/php/7.2/apache2/php.ini.tmp && mv /etc/php/7.2/apache2/php.ini.tmp /etc/php/7.2/apache2/php.ini
+sed -e "s/memory_limit = 128M/memory_limit = 512M/g" /etc/php/7.2/cli/php.ini > /etc/php/7.2/cli/php.ini.tmp && mv /etc/php/7.2/cli/php.ini.tmp /etc/php/7.2/cli/php.ini
+systemctl restart apache2.service
+
+#Composer ist bisher nur in Testing vorhanden, daher installieren wir nun manuell
+pushd /tmp
+wget -O - "https://gist.githubusercontent.com/adlerweb/b63784bd859e63ac0bbd8ea85ec161da/raw/54ae771120880364df75141f9d5c39bd82439a4c/composersetup.sh" | sh
+mv composer.phar /usr/local/bin/composer
+popd
+
+#AdAr Herunterladen
+install -o www-data -d /var/www/html/adar/
+pushd /var/www/html/adar
+su -s $SHELL -c 'git clone https://github.com/adlerweb/adar.git .' www-data
+
+#Abhängigkeiten installieren
+install -o www-data -d /var/www/.composer/
+su -s $SHELL -c 'composer install' www-data
+
+#MySQL/MariaDB einrichten
+read -s -p "Database root password? " sqlroot
+echo
+sqlpw=$(base64 /dev/urandom | tr -d '/+' | dd bs=32 count=1 2>/dev/null)
+
+sql="CREATE USER 'adar'@'localhost' IDENTIFIED BY '$sqlpw'; "
+sql+="CREATE DATABASE adar; "
+sql+="GRANT ALL PRIVILEGES ON \`adar\`.* TO 'adar'@'localhost'; "
+sql+="FLUSH PRIVILEGES; "
+sql+="USE adar; "
+sql+=$(cat doc/mysql.sql)
+echo "$sql" | mysql -uroot -p"$sqlroot"
+unset sqlroot
+unset sql
+
+#Konfiguration anpassen
+sed -e "s/testinstallation/$sqlpw/g" config.php > config.php.tmp && mv config.php.tmp config.php
+
+read -p "Absendeadresse für E-Mails? [ADAR <adar@localhost>] " cfgtmp
+echo
+if [[ -z "${cfgtmp// }" ]] ;then
+	cfgtmp="ADAR <adar@localhost>"
+fi
+sed -e "s/ADAR <adar@localhost>/$cfgtmp/g" config.php > config.php.tmp && mv config.php.tmp config.php
+
+read -p "E-Mail für Benachrichtigung bei Neuanlagen? (Leer = Keine Infomail) " cfgtmp
+echo
+if [[ ! -z "${cfgtmp// }" ]] ;then
+	sed -e "s/''/'$cfgtmp'/g" config.php > config.php.tmp && mv config.php.tmp config.php
+fi
+
+unset cfgtmp
+
+# Admin-Passwort festlegen
+read -s -p "Passwort für admin? " cfgtmp
+echo
+
+cfgtmp=$(echo "<?php require('vendor/adlerweb/awtools/session.php'); \$sess = new adlerweb_session; echo \$sess->session_getNewPasswordHash("$cfgtmp"); ?>" | php 2>/dev/null)
+
+if [[ ! -z "${cfgtmp// }" ]] ;then
+	echo "UPDATE Users SET Password = '$cfgtmp' WHERE Nickname = 'admin' LIMIT 1;" | mysql -uadar -p"$sqlpw" adar
+else
+	echo "Fehler - Passwort wurde nicht geändert, login mit admin:admin"
+fi
+
+unset sqlpw
+unset cfgtmp
+
+#Cronjob einrichten
+echo '*/5 * * * * /usr/bin/php -f /var/www/html/adar/cron.php > /var/log/adar.cron.log' > /etc/cron.d/adar
+
+#Done
+popd
+echo Setup abgeschlossen


### PR DESCRIPTION
Add the "setup-ubuntu18.04.sh", add the "setup-ubuntu16.04.sh" and adjust the readme.md
(successfully tested in a ubuntu 18.04 and ubuntu 16.04 VM. Only i686 works, doesn't work on amd64 because of issue #17